### PR TITLE
introduce mongo transfer size tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,12 +152,12 @@ AC_ARG_ENABLE([tcmalloc-unclamped-transfer-sizes],
               [],
               [])
 
-unclamped_transfer_sizes=0
-AS_IF([test "x$enable_unclamped_transfer_sizes" = "xyes"],
-      [unclamped_transfer_sizes=1],
+use_unclamped_transfer_sizes=0
+AS_IF([test "x$enable_tcmalloc_unclamped_transfer_sizes" = "xyes"],
+      [use_unclamped_transfer_sizes=1],
       [])
 AC_DEFINE_UNQUOTED(TCMALLOC_USE_UNCLAMPED_TRANSFER_SIZES,
-                   [$unclamped_transfer_sizes],
+                   [$use_unclamped_transfer_sizes],
                    [A detail of the "blocks_to_move" loop of "SizeMap::Init"])
 
 case "$with_tcmalloc_pagesize" in

--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,26 @@ AS_IF([test "x$enable_tcmalloc_aggressive_merge" = "xyes"],
                  [Define to 1 to try to reduce the number of size classes.])],
       [])
 
+AC_ARG_ENABLE([tcmalloc-target-transfer-kb],
+              AS_HELP_STRING([--enable-tcmalloc-target-transfer-kb],
+                             [Optimal transfer size between thread and central caches,
+                              in kiB [default=64]]),
+              [],
+              [enable_tcmalloc_target_transfer_kb=64])
+AC_DEFINE_UNQUOTED(TCMALLOC_TARGET_TRANSFER_KB,
+                   [$enable_tcmalloc_target_transfer_kb],
+                   [Optimal transfer size between thread and central caches])
+
+AC_ARG_ENABLE([tcmalloc-objects-per-block],
+              AS_HELP_STRING([--enable-tcmalloc-objects-per-block],
+                             [The "/4" divisor in the "blocks_to_move" loop of "SizeMap::Init"
+                              [default=4]]),
+              [],
+              [enable_tcmalloc_objects_per_block=4])
+AC_DEFINE_UNQUOTED(TCMALLOC_OBJECTS_PER_BLOCK,
+                   [$enable_tcmalloc_objects_per_block],
+                   [The "/4" divisor in the "blocks_to_move" loop of "SizeMap::Init"])
+
 case "$with_tcmalloc_pagesize" in
   4)
        AC_DEFINE(TCMALLOC_PAGE_SIZE_SHIFT, 12);;

--- a/configure.ac
+++ b/configure.ac
@@ -146,15 +146,19 @@ AC_DEFINE_UNQUOTED(TCMALLOC_TARGET_TRANSFER_KB,
                    [$enable_tcmalloc_target_transfer_kb],
                    [Optimal transfer size between thread and central caches])
 
-AC_ARG_ENABLE([tcmalloc-objects-per-block],
-              AS_HELP_STRING([--enable-tcmalloc-objects-per-block],
-                             [The "/4" divisor in the "blocks_to_move" loop of "SizeMap::Init"
-                              [default=4]]),
+AC_ARG_ENABLE([tcmalloc-unclamped-transfer-sizes],
+              AS_HELP_STRING([--enable-unclamped-transfer-sizes],
+                             [A detail of the "blocks_to_move" loop of "SizeMap::Init"]),
               [],
-              [enable_tcmalloc_objects_per_block=4])
-AC_DEFINE_UNQUOTED(TCMALLOC_OBJECTS_PER_BLOCK,
-                   [$enable_tcmalloc_objects_per_block],
-                   [The "/4" divisor in the "blocks_to_move" loop of "SizeMap::Init"])
+              [])
+
+unclamped_transfer_sizes=0
+AS_IF([test "x$enable_unclamped_transfer_sizes" = "xyes"],
+      [unclamped_transfer_sizes=1],
+      [])
+AC_DEFINE_UNQUOTED(TCMALLOC_USE_UNCLAMPED_TRANSFER_SIZES,
+                   [$unclamped_transfer_sizes],
+                   [A detail of the "blocks_to_move" loop of "SizeMap::Init"])
 
 case "$with_tcmalloc_pagesize" in
   4)

--- a/src/common.cc
+++ b/src/common.cc
@@ -52,6 +52,9 @@ static const bool kUseAggressiveMerge = true;
 static const bool kUseAggressiveMerge = false;
 #endif
 
+static const size_t kTargetTransferBytes = TCMALLOC_TARGET_TRANSFER_KB * 1024;
+static const size_t kObjectsPerBlock = TCMALLOC_OBJECTS_PER_BLOCK;
+
 // The init function is provided to explicit initialize the variable value
 // from the env. var to avoid C++ global construction that might defer its
 // initialization after a malloc/new call.
@@ -173,7 +176,7 @@ static bool MergeOkayByNaturalAlignment(const int32 *class_to_size, size_t first
 int SizeMap::NumMoveSize(size_t size) {
   if (size == 0) return 0;
   // Use approx 64k transfers between thread and central caches.
-  int num = static_cast<int>(64.0 * 1024.0 / size);
+  int num = kTargetTransferBytes /size;
   if (num < 2) num = 2;
 
   // Avoid bringing too many objects into small object free lists.
@@ -213,7 +216,7 @@ void SizeMap::Init() {
   for (size_t size = kAlignment; size <= kMaxSize; size += AlignmentForSize(size)) {
     CHECK_CONDITION((size % AlignmentForSize(size)) == 0);
 
-    int blocks_to_move = NumMoveSize(size) / 4;
+    int blocks_to_move = NumMoveSize(size) / kObjectsPerBlock;
     size_t psize = 0;
     do {
       psize += kPageSize;

--- a/src/common.cc
+++ b/src/common.cc
@@ -53,7 +53,7 @@ static const bool kUseAggressiveMerge = false;
 #endif
 
 static const size_t kTargetTransferBytes = TCMALLOC_TARGET_TRANSFER_KB * 1024;
-static const size_t kObjectsPerBlock = TCMALLOC_OBJECTS_PER_BLOCK;
+static const bool kUseUnclampedTransferSizes = TCMALLOC_USE_UNCLAMPED_TRANSFER_SIZES;
 
 // The init function is provided to explicit initialize the variable value
 // from the env. var to avoid C++ global construction that might defer its
@@ -215,8 +215,9 @@ void SizeMap::Init() {
   CHECK_CONDITION(kAlignment <= kMinAlign);
   for (size_t size = kAlignment; size <= kMaxSize; size += AlignmentForSize(size)) {
     CHECK_CONDITION((size % AlignmentForSize(size)) == 0);
+    int blocks_to_move = kUseUnclampedTransferSizes ?
+      (kTargetTransferBytes / size) : (NumMoveSize(size) / 4);
 
-    int blocks_to_move = NumMoveSize(size) / kObjectsPerBlock;
     size_t psize = 0;
     do {
       psize += kPageSize;

--- a/src/common.h
+++ b/src/common.h
@@ -229,6 +229,9 @@ class SizeMap {
 
   int NumMoveSize(size_t size);
 
+  // Calculate # of pages to give a size class.
+  size_t PagesForSizeClass(size_t size);
+
   // Mapping from size class to max size storable in that class
   int32 class_to_size_[kClassSizesMax];
 

--- a/src/common.h
+++ b/src/common.h
@@ -227,10 +227,10 @@ class SizeMap {
   // per-thread free list until the scavenger cleans up the list.
   int num_objects_to_move_[kClassSizesMax];
 
-  int NumMoveSize(size_t size);
+  int NumMoveSize(size_t size) const;
 
-  // Calculate # of pages to give a size class.
-  size_t PagesForSizeClass(size_t size);
+  // Compute # of pages to give a size class.
+  size_t ComputePagesForSizeClass(size_t size) const;
 
   // Mapping from size class to max size storable in that class
   int32 class_to_size_[kClassSizesMax];


### PR DESCRIPTION
Brings mongo's changes to gperftools-2.5 available as configure options based on gperftools 2.7.
https://github.com/mongodb/mongo/commit/99436618a0fe429ae5519b02e13f0b22cac5eba1

